### PR TITLE
Update installer.nsi

### DIFF
--- a/resources/windows/installer.nsi
+++ b/resources/windows/installer.nsi
@@ -83,6 +83,41 @@ Var LaunchAppCheckbox_State
 ;   --------------------------------
 
 Function .onInit
+
+    ;   --------------------------------
+    ;    Checking previously installed version
+    ;   --------------------------------
+
+    ReadRegStr $R0 HKLM \
+    "Software\Microsoft\Windows\CurrentVersion\Uninstall\${productName}" \
+    "UninstallString"
+    StrCmp $R0 "" done
+
+    MessageBox MB_OKCANCEL|MB_ICONEXCLAMATION \
+    "${productName} is already installed. $\n$\nClick `OK` to remove the \
+    previous version or `Cancel` to cancel this upgrade." \
+    IDOK uninst
+    Abort
+    ;   --------------------------------
+    ;    Run the uninstaller
+    ;   --------------------------------
+    uninst:
+    ClearErrors
+    ExecWait '$R0 _?=$INSTDIR' ;Do not copy the uninstaller to a temp file
+
+    IfErrors no_remove_uninstaller done
+      ;You can either use Delete /REBOOTOK in the uninstaller or add some code
+      ;here to remove the uninstaller. Use a registry key to check
+      ;whether the user has chosen to uninstall. If you are using an uninstaller
+      ;components page, make sure all sections are uninstalled.
+    no_remove_uninstaller:
+
+    done:
+    ;   --------------------------------
+    ;    End of uninstaller
+    ;   --------------------------------
+
+
     ; Set installer to silent if /silent switch was provided
     ${GetParameters} $R0
     ${GetOptionsS} $R0 "/silent" $0


### PR DESCRIPTION
@RocketChat/core 

Sometimes on windows machine , installing a new version gives error and doesn't change icons and other system cached files over the previous version. With these changes, the installer will detect a previous version of the program if applicable and then ask to completely uninstall it by running the uninstaller and then start with new installation process.

